### PR TITLE
limit character jump to one per keypress

### DIFF
--- a/lib/plusplus/abstractities/character.js
+++ b/lib/plusplus/abstractities/character.js
@@ -776,7 +776,7 @@ ig.module(
              **/
             jump: function () {
 
-                if (this.canJump) {
+                if ( this.canJump && ig.input.pressed('jump') ) {
 
                     if (this.climbing) {
 


### PR DESCRIPTION
Hi Collin,

I was having an issue when jumping into collision maps and entities. the player would stick to elements above itself if the spacebar is still pressed when the collision is detected. If you are holding the spacebar the player also bounces on landing which doesn't feel desirable.

Thanks,
Ray.
