### PR TITLE
Fix for EntityExtended ignoring stop/once values in animSettings

### DIFF
--- a/examples/jumpnrun/lib/plusplus/core/animation.js
+++ b/examples/jumpnrun/lib/plusplus/core/animation.js
@@ -263,6 +263,10 @@ ig.module(
              **/
             playFromStart: function (once) {
 
+                if ((once == undefined) && (this.once != undefined)) {
+                    once = this.once;
+                }
+
                 this.stop = false;
                 this.rewind(once);
 
@@ -275,6 +279,10 @@ ig.module(
              **/
             rewind: function (once) {
 
+                if ((once == undefined) && (this.once != undefined)) {
+                    once = this.once;
+                }
+                
                 this.once = once;
 
                 return this.parent();

--- a/examples/jumpnrun/lib/plusplus/core/entity.js
+++ b/examples/jumpnrun/lib/plusplus/core/entity.js
@@ -928,7 +928,7 @@ ig.module(
 
                 }
 
-                this.addAnim(name || ( typeof this.animInit === 'string' ? this.animInit : 'idle' ), settings.frameTime || this.animFrameTime, sequence);
+                this.addAnim(name || ( typeof this.animInit === 'string' ? this.animInit : 'idle' ), settings.frameTime || this.animFrameTime, sequence, settings.stop || false, settings.once || false);
 
             },
 
@@ -939,9 +939,10 @@ ig.module(
              * @param {Number} frameTime duration per frame
              * @param {Array} sequence indices of animation sheet tiles
              * @param {Boolean} [stop] don't play
+             * @param {Boolean} [once] play animation only once
              * @see ig.Entity.
              */
-            addAnim: function (name, frameTime, sequence, stop) {
+            addAnim: function (name, frameTime, sequence, stop, once) {
 
                 if (!this.animSheet) {
 
@@ -949,7 +950,7 @@ ig.module(
 
                 }
 
-                var animation = new ig.AnimationExtended(this.animSheet, frameTime, sequence, stop);
+                var animation = new ig.AnimationExtended(this.animSheet, frameTime, sequence, stop, once);
 
                 this.anims[name] = animation;
 

--- a/lib/plusplus/core/animation.js
+++ b/lib/plusplus/core/animation.js
@@ -263,6 +263,10 @@ ig.module(
              **/
             playFromStart: function (once) {
 
+                if ((once == undefined) && (this.once != undefined)) {
+                    once = this.once;
+                }
+
                 this.stop = false;
                 this.rewind(once);
 
@@ -275,6 +279,10 @@ ig.module(
              **/
             rewind: function (once) {
 
+                if ((once == undefined) && (this.once != undefined)) {
+                    once = this.once;
+                }
+                
                 this.once = once;
 
                 return this.parent();

--- a/lib/plusplus/core/entity.js
+++ b/lib/plusplus/core/entity.js
@@ -928,7 +928,7 @@ ig.module(
 
                 }
 
-                this.addAnim(name || ( typeof this.animInit === 'string' ? this.animInit : 'idle' ), settings.frameTime || this.animFrameTime, sequence);
+                this.addAnim(name || ( typeof this.animInit === 'string' ? this.animInit : 'idle' ), settings.frameTime || this.animFrameTime, sequence, settings.stop || false, settings.once || false);
 
             },
 
@@ -939,9 +939,10 @@ ig.module(
              * @param {Number} frameTime duration per frame
              * @param {Array} sequence indices of animation sheet tiles
              * @param {Boolean} [stop] don't play
+             * @param {Boolean} [once] play animation only once
              * @see ig.Entity.
              */
-            addAnim: function (name, frameTime, sequence, stop) {
+            addAnim: function (name, frameTime, sequence, stop, once) {
 
                 if (!this.animSheet) {
 
@@ -949,7 +950,7 @@ ig.module(
 
                 }
 
-                var animation = new ig.AnimationExtended(this.animSheet, frameTime, sequence, stop);
+                var animation = new ig.AnimationExtended(this.animSheet, frameTime, sequence, stop, once);
 
                 this.anims[name] = animation;
 


### PR DESCRIPTION
`stop` and `once` values in EntityExtended.animSettings were being
ignored.

Specifically, this fix changes...
- _core/entity.js_ -> `createAnim` - pass settings.stop/once to addAnim
- _core/entity.js_ -> `addAnim` - added once param
- _core/animation.js_ -> `playFromStart` - check for once in settings
- _core/animation.js_ -> `rewind` - check for once in settings

I added issue https://github.com/collinhover/impactplusplus/issues/30 to represent the issue that this should fix.
