### PR TITLE
CAN_FLIP_X

### DIFF
--- a/examples/jumpnrun/lib/plusplus/config-user.js
+++ b/examples/jumpnrun/lib/plusplus/config-user.js
@@ -25,8 +25,9 @@ ig.module(
 			/*
 			TOP_DOWN: true,
 			ENTITY: {
+				CAN_FLIP_X: true,
 				CAN_FLIP_Y: true
-			}
+			},
 			*/
 
             /**

--- a/lib/plusplus/core/entity.js
+++ b/lib/plusplus/core/entity.js
@@ -192,6 +192,13 @@ ig.module(
              * @type Boolean
 			 * @default
              */
+            canFlipX: _c.ENTITY.CAN_FLIP_X,
+
+             /**
+             * Whether entity can flip animations vertically and set facing on y.
+             * @type Boolean
+			 * @default
+             */
             canFlipY: _c.ENTITY.CAN_FLIP_Y,
 
             /**
@@ -3489,7 +3496,7 @@ ig.module(
 							
 							if ( xDiff > 0 ) {
 								
-								this.flip.x = true;
+								this.flip.x = this.canFlipX;
 								this.facing.x = -1;
 								
 							}
@@ -4290,7 +4297,7 @@ ig.module(
 						
 						if ( this.vel.x < 0 ) {
 							
-							this.flip.x = true;
+							this.flip.x = this.canFlipX;
 							this.facing.x = -1;
 						
 						}


### PR DESCRIPTION
I have need of entity sprites that are asymmetrical in the x-direction, mostly due to things like hairstyles, eye patches, etc.

When _core/entity.js_ sets _this.flip.x_ to _true_, it seems to prevent the ability to have different animations for the left and right directions.

This pull adds support for _CAN_FLIP_X_ in the config file.
