### PR TITLE
Fix current animation to fallback to idle on top-down mode

### DIFF
--- a/lib/plusplus/abstractities/character.js
+++ b/lib/plusplus/abstractities/character.js
@@ -2448,10 +2448,15 @@ ig.module(
 					}
                     else if (_c.TOP_DOWN) {
 						
-						this.currentAnim = anims[ this.getDirectionalAnimName( "move" ) ];
 						this.currentAnim.stop = !this.moving;
-						
-						return true;
+
+			                        if ( this.moving ) {
+			
+			                            this.currentAnim = anims[ this.getDirectionalAnimName( "move" ) ];
+			
+			                            return true;
+			
+			                        }
 
                     }
                     else if ( this.moving ) {


### PR DESCRIPTION
If the entity is eg. a player, performace is dynamic, so the first

``` javascript
if (this.performance === _c.DYNAMIC) {
```

always applies. If on top-down mode, we'll also always go to

``` javascript
else if (_c.TOP_DOWN) {
```

and this used to always set the animation to "move" and return true (= using non-idle animation).

So it never felt back to idle.

I think this committed code is the intended behavior and my quick test seems to indicate so.
