### PR TITLE
disabled casting shadows on pixel perfect lights in combination with cas...

### DIFF
--- a/lib/plusplus/entities/light.js
+++ b/lib/plusplus/entities/light.js
@@ -171,6 +171,7 @@ ig.module(
             /**
              * Whether light should be drawn and scaled pixel perfectly.
              * <span class="alert alert-danger"><strong>IMPORTANT:</strong> pixel perfect scaling has a very high performance cost, use carefully!</span>
+             * <br>- doesn't work in combination with {@link ig.EntityLight#castsShadowsMovable} due to performance reasons
              * @type Boolean
              * @default
              */
@@ -197,6 +198,7 @@ ig.module(
              * Whether light should cast shadows on movable objects that are {@link ig.EntityExtended#opaque}.
              * <br>- <strong>IMPORTANT:</strong> casting shadows can have a higher performance cost, use carefully!
              * <br>- to cast shadows, light must also {@link ig.EntityLight#castsShadows}
+             * <br>- doesn't work in combination with {@link ig.EntityLight#pixelPerfect} due to performance reasons
              * @type Boolean
              * @default
              */
@@ -621,7 +623,7 @@ ig.module(
 
                             // under and within light
 
-                            if (item._killed !== true && (item.performance === ig.EntityExtended.PERFORMANCE.STATIC || this.castsShadowsMovable) && _uti.AABBIntersect(
+                            if (item._killed !== true && (item.performance === ig.EntityExtended.PERFORMANCE.STATIC || this.castsShadowsMovable && !this.pixelPerfect) && _uti.AABBIntersect(
                                 minX, minY, maxX, maxY,
                                 item.pos.x, item.pos.y, item.pos.x + item.size.x, item.pos.y + item.size.y
                             )) {


### PR DESCRIPTION
Hi @collinhover,

i played around with a fix regarding to Issue #128. The simplest way in my opinion, is to avoid adding opaque entities if `pixelPerfect` and `castsShadowsMovable` is true. All other solutions that i have tried, had the side effect off disabling shadow casting based on the collision map as well.

I also altered the docs regarding to that. 
