### PR TITLE
UIButtons don't take into account scale for the clickable area.

### DIFF
--- a/lib/plusplus/helpers/utilsintersection.js
+++ b/lib/plusplus/helpers/utilsintersection.js
@@ -588,14 +588,14 @@ ig.module(
                         var screenY = ig.game.screen.y;
 
                         intersects = ig.utilsintersection.AABBIntersect(
-                            entity.pos.x + screenX, entity.pos.y + screenY, entity.pos.x + entity.size.x + screenX, entity.pos.y + entity.size.y + screenY,
+                            entity.pos.x + screenX, entity.pos.y + screenY, entity.pos.x + (entity.size.x * entity.scaleMod) + screenX, entity.pos.y + (entity.size.y * entity.scaleMod) + screenY,
                             minX, minY, maxX, maxY
                         );
 
                     } else {
 
                         intersects = ig.utilsintersection.AABBIntersect(
-                            entity.pos.x, entity.pos.y, entity.pos.x + entity.size.x, entity.pos.y + entity.size.y,
+                            entity.pos.x, entity.pos.y, entity.pos.x + (entity.size.x * entity.scaleMod), entity.pos.y + (entity.size.y * entity.scaleMod),
                             minX, minY, maxX, maxY
                         );
 


### PR DESCRIPTION
utilsintersection.entitiesInAABB checks intersection by size, but doesn't take into account the scale of the entity. This causes large buttons to only register taps in the top left corner while the bottom right corner is ignored. This commit fixes the issue by multiplying entity size by the entity's scaleMod. That way the entire button's surface is now clickable.
