### PR TITLE
Multiple jump for characters

### DIFF
--- a/lib/plusplus/abstractities/character.js
+++ b/lib/plusplus/abstractities/character.js
@@ -234,6 +234,21 @@ ig.module(
             jumpControl: _c.CHARACTER.JUMP_CONTROL,
 
             /**
+             * Whether character can do additional jumps while in air.
+             * @type Boolean
+             * @default
+             */
+            canJumpRepeatedly: _c.CHARACTER.CAN_JUMP_REPEATEDLY,
+
+            /**
+             * How many additional jumps character can do while in air.
+             * @see ig.CONFIG.CHARACTER.CAN_JUMP_REPEATEDLY
+             * @type Number
+             * @default
+             */
+            additionalJumps: 1,
+
+            /**
              * Whether character is able to climb.
              * @type Boolean
              * @default
@@ -625,6 +640,8 @@ ig.module(
 
             _jumpPushing: false,
             _jumpWhileClimbing: false,
+            _jumpCounter: 0,
+            _canUseAdditionalJump: false,
 
             _climbingIntentDown: false,
             _climbingIntentUp: false,
@@ -1850,10 +1867,18 @@ ig.module(
 
                     }
 
-                    if ((this.grounded || (this.canClimb && this.withinClimbables) || this.ungroundedFor < this.ungroundedForThreshold) && this.jumping !== true) {
+                    if(this.canJumpRepeatedly){
+
+                        this._canUseAdditionalJump = this.additionalJumps >= this._jumpCounter;
+
+                    }
+
+                    if ((this.grounded || (this.canClimb && this.withinClimbables) || this.ungroundedFor < this.ungroundedForThreshold) && this.jumping !== true || this._canUseAdditionalJump) {
 
                         this.jumping = this._jumpPushing = true;
                         this.jumpStepsRemaining = this.jumpSteps;
+
+                        this._jumpCounter++;
 
                     }
 
@@ -1929,6 +1954,8 @@ ig.module(
 
                 this.jumping = this._jumpPushing = false;
                 this.jumpStepsRemaining = 0;
+                this._jumpCounter = 0;
+                this._canUseAdditionalJump = this.canJumpRepeatedly;
 
                 if (this._jumpWhileClimbing) {
 

--- a/lib/plusplus/core/config.js
+++ b/lib/plusplus/core/config.js
@@ -1726,6 +1726,14 @@ ig.module(
         ig.CONFIG.CHARACTER.JUMP_CONTROL = 0.75;
 
         /**
+         * Whether character can do additional jumps while in air.
+         * @type Boolean
+         * @default
+         * @memberof ig.CONFIG.CHARACTER
+         */
+        ig.CONFIG.CHARACTER.CAN_JUMP_REPEATEDLY = false;
+
+        /**
          * Whether character should stick to slopes instead of sliding down.
          * @type Boolean
          * @default


### PR DESCRIPTION
Here is the multiple jump functionality we talked about. Because I already played games where you can do a triple or quadruple jump (rogue legacy for example) this is not strict for “double jumps”. Instead you can define how many additional jumps you like once you are in the air.

I made a new property `canJumpRepeatedly` which is also present in the config and by default false. Also there is a new property `additionalJumps`, where the user can define the amount of additional jumps. For example, 1 results in  in one additional jump, so we have a classic double jump. 

The `additionalJumps` property is not present in the config, because I thought that this will be specific to the entity. For example, some enemies can double jump, but just the player can do a triple jump.

There are also two new internal properties, one counter for the jumps and one for triggering the actual extra jump. I reset those at the `jumpEnd` method. 

I modified the `jump` method just a little bit. Basically I just check if an additional jump is possible and modify the specific property, so that a jump will be triggered. 

If you think everything is cool with the code, it would be great if you can merge this with the current dev branch. If not, please tell me how I can improve the code. 
